### PR TITLE
chore: add java-docs-samples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ https://github.com/googleapis/google-cloud-java/tree/main/java-beyondcorp-client
 This repository will be archived in the future.
 Future releases will appear in the new repository (https://github.com/googleapis/google-cloud-java/releases).
 The Maven artifact coordinates (`com.google.cloud:google-cloud-beyondcorp-clientgateways`) remain the same.
+Sample code is in https://github.com/GoogleCloudPlatform/java-docs-samples.
 
 ## Quickstart
 


### PR DESCRIPTION
The code in this repository has moved to https://github.com/googleapis/google-cloud-java/tree/main/java-beyondcorp-clientgateways and https://github.com/GoogleCloudPlatform/java-docs-samples